### PR TITLE
fix: adjust the code style

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -12,7 +12,7 @@ pub enum BranchStatus {
   Merged(String),     // branch merged can be deleted
   RemoteGone(String), // remote branch deleted
   Diverged(String),   // local has unpushed commits
-  UpToDate(),   // branch is already up to date
+  UpToDate,   // branch is already up to date
   LocalOnly(String),  // local branch never pushed
   Modified(String),   // has uncommitted changes
 }
@@ -171,7 +171,7 @@ impl GitManager {
         let right: usize = right.parse().unwrap_or(0);
 
         match (left, right) {
-          (0, 0) => Ok(BranchStatus::UpToDate()),
+          (0, 0) => Ok(BranchStatus::UpToDate),
           (_, 0) => Ok(BranchStatus::Diverged(branch.to_string())),
           (0, _) => {
             if self.check_remote_branch(branch)? {
@@ -185,7 +185,7 @@ impl GitManager {
                 self.update_branch_ref(branch, &format!("refs/remotes/origin/{}", branch))?;
                 Ok(BranchStatus::Updated(branch.to_string()))
               } else {
-                Ok(BranchStatus::UpToDate())
+                Ok(BranchStatus::UpToDate)
               }
             } else {
               Ok(BranchStatus::RemoteGone(branch.to_string()))

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -143,9 +143,7 @@ pub fn handle_sync_command(git: &GitManager) -> Result<(), Box<dyn std::error::E
           branch
         );
       }
-      BranchStatus::UpToDate() => {
-        // Do nothing
-      }
+      BranchStatus::UpToDate => ()
     }
   }
 


### PR DESCRIPTION
-  `UpToDate()` ->  `UpToDate` , we don't need the parenthesis if the enum doesn't have any argument.
- `BranchStatus::UpToDate => ()`, we can directly return the unit struct if we don't want to do anything.