### PR TITLE
Add worktree display to branch selection commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Swagit is an interactive Git CLI tool written in Rust that provides a fuzzy-searchable interface for common Git operations. The tool was rewritten from Node.js/TypeScript to Rust starting from version 1.0.0 for better performance.
+
+## Architecture
+
+### Core Components
+
+- **GitManager** (`src/git.rs`): Core Git operations wrapper that handles all Git command execution and provides methods for branch management, status checking, and synchronization
+- **Handlers** (`src/handlers.rs`): Command-specific implementations for the three main operations:
+  - `handle_checkout_command`: Interactive branch selection and switching
+  - `handle_delete_command`: Multi-select branch deletion with confirmation
+  - `handle_sync_command`: Remote sync with automatic cleanup of merged branches
+- **Main** (`src/main.rs`): CLI setup, argument parsing, and command routing
+
+### Key Data Structures
+
+- `BranchInfo`: Contains branch name and commit ID
+- `BranchStatus` enum: Tracks various branch states (Updated, Merged, RemoteGone, Diverged, UpToDate, LocalOnly, Modified)
+
+## Development Commands
+
+### Building and Testing
+```bash
+# Build the project
+cargo build
+
+# Run tests
+cargo test
+
+# Run specific test file
+cargo test --test git_tests
+cargo test --test integration_tests
+
+# Build release version
+cargo build --release
+
+# Format code
+cargo fmt
+
+# Run clippy linting
+cargo clippy
+```
+
+### Package Management (Legacy npm wrapper)
+```bash
+# Install dependencies for npm wrapper
+pnpm install
+
+# Publish changeset (for releases)
+pnpm changeset
+pnpm release
+```
+
+## Key Implementation Details
+
+### Branch Synchronization Logic
+The sync functionality (`sync_branches()` in GitManager) performs a complex workflow:
+1. Checks for uncommitted changes
+2. Updates remote references with `git remote update --prune`
+3. Identifies merged branches using `git branch --merged`
+4. Automatically deletes merged branches
+5. Checks status of remaining branches using `git rev-list --left-right --count`
+
+### Interactive CLI Features
+- Uses `dialoguer` crate for interactive prompts with fuzzy search
+- Handles both interactive (TTY) and non-interactive modes
+- Graceful Ctrl-C handling with proper cursor cleanup
+
+### Cross-Platform Distribution
+The project uses a multi-package structure under `packages/` for platform-specific npm distributions while the main Rust binary is distributed via crates.io.
+
+## Common Patterns
+
+- Error handling uses `Box<dyn std::error::Error>` throughout
+- Git commands are executed via `std::process::Command` and wrapped in the `GitManager::command()` method
+- All user-facing output uses the `colored` crate for terminal colors
+- Interactive prompts check for TTY before presenting UI
+
+## Testing Strategy
+
+Tests are located in `tests/` directory and use:
+- `assert_cmd` for CLI testing
+- `tempfile` for creating temporary Git repositories
+- `predicates` for output assertions
+- Test setup creates full Git repositories with proper configuration

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13,7 +13,15 @@ pub fn handle_checkout_command(git: &GitManager) -> Result<(), Box<dyn std::erro
 
   let branch_names: Vec<String> = branches
     .iter()
-    .map(|b| format!("{} [{}]", b.name, b.commit_id))
+    .map(|b| {
+      let mut display = format!("{} [{}]", b.name, b.commit_id);
+      if let Some(worktree_path) = &b.worktree_path {
+        if let Some(worktree_name) = std::path::Path::new(worktree_path).file_name() {
+          display.push_str(&format!(" ({})", worktree_name.to_string_lossy()));
+        }
+      }
+      display
+    })
     .collect();
 
   if atty::is(atty::Stream::Stdin) && atty::is(atty::Stream::Stdout) {
@@ -49,7 +57,15 @@ pub fn handle_delete_command(git: &GitManager) -> Result<(), Box<dyn std::error:
 
   let branch_names: Vec<String> = branches
     .iter()
-    .map(|b| format!("{} [{}]", b.name, b.commit_id))
+    .map(|b| {
+      let mut display = format!("{} [{}]", b.name, b.commit_id);
+      if let Some(worktree_path) = &b.worktree_path {
+        if let Some(worktree_name) = std::path::Path::new(worktree_path).file_name() {
+          display.push_str(&format!(" ({})", worktree_name.to_string_lossy()));
+        }
+      }
+      display
+    })
     .collect();
 
   let selections = match MultiSelect::with_theme(&ColorfulTheme::default())


### PR DESCRIPTION
## Summary
• Add worktree detection to branch listing functionality
• Display worktree name alongside branch info in delete and checkout commands  
• Branches checked out in worktrees now show as "branch-name [commit] (worktree-name)"

## Test plan
- [ ] Build project successfully with `cargo build`
- [ ] Run existing tests with `cargo test` 
- [ ] Create test repository with worktrees and verify display format
- [ ] Test both delete (`swagit -d`) and checkout (`swagit`) commands show worktree info
- [ ] Verify branches without worktrees still display normally

🤖 Generated with [Claude Code](https://claude.ai/code)