### PR TITLE
Fix sync command deleting current branch

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -115,6 +115,7 @@ impl GitManager {
           && branch != &default_branch
           && branch != "master"
           && branch != "main"
+          && branch != &current
           && !branch.starts_with('*')
         {
           Some(branch.to_string())

--- a/tests/git_tests.rs
+++ b/tests/git_tests.rs
@@ -141,3 +141,93 @@ fn test_sync_with_no_remote() {
     .failure()
     .stderr(predicate::str::contains("No remote repository configured"));
 }
+
+#[test]
+fn test_sync_does_not_delete_current_branch() {
+  let temp_dir = setup_git_repo();
+  
+  // Create a bare repository to act as remote
+  let remote_dir = TempDir::new().unwrap();
+  StdCommand::new("git")
+    .args(["init", "--bare"])
+    .current_dir(&remote_dir)
+    .output()
+    .expect("Failed to create bare repo");
+  
+  // Add remote to our repo
+  StdCommand::new("git")
+    .args(["remote", "add", "origin", remote_dir.path().to_str().unwrap()])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to add remote");
+  
+  // Push main to remote
+  StdCommand::new("git")
+    .args(["push", "-u", "origin", "main"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to push main");
+  
+  // Create and switch to a new branch
+  StdCommand::new("git")
+    .args(["checkout", "-b", "test-branch"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to create test branch");
+  
+  // Create a commit
+  std::fs::write(temp_dir.path().join("test.txt"), "test").unwrap();
+  StdCommand::new("git")
+    .args(["add", "test.txt"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to add file");
+  StdCommand::new("git")
+    .args(["commit", "-m", "test commit"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to commit");
+  
+  // Switch to main and merge the test branch
+  StdCommand::new("git")
+    .args(["checkout", "main"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to switch to main");
+  StdCommand::new("git")
+    .args(["merge", "test-branch"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to merge test branch");
+  
+  // Push the merged main
+  StdCommand::new("git")
+    .args(["push", "origin", "main"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to push merged main");
+  
+  // Switch back to test-branch
+  StdCommand::new("git")
+    .args(["checkout", "test-branch"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to switch back to test branch");
+  
+  // Run sync - should not delete the current branch even though it's merged
+  Command::cargo_bin("swagit")
+    .unwrap()
+    .current_dir(&temp_dir)
+    .arg("-s")
+    .assert()
+    .success();
+  
+  // Verify the current branch still exists
+  let output = StdCommand::new("git")
+    .args(["branch", "--show-current"])
+    .current_dir(&temp_dir)
+    .output()
+    .expect("Failed to get current branch");
+  
+  assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "test-branch");
+}


### PR DESCRIPTION
## Summary
- Fix critical bug where `swagit -s` could delete the current branch
- Add merged branch filtering logic to exclude current branch
- Add comprehensive test case to prevent regression

## Problem
The `sync_branches()` function was incorrectly identifying and deleting the current branch when it was considered "merged" by Git's `git branch --merged` command. This created a dangerous situation where users could lose their active working branch.

## Root Cause
The merged branch filtering logic in `src/git.rs` (lines 109-125) was missing a check for the current branch, allowing it to be included in the `merged_branches` list for deletion.

## Solution
- Added `&& branch != &current` condition to the merged branch filter
- Added `test_sync_does_not_delete_current_branch` test case
- Ensures current branch is always preserved during sync operations

## Test Plan
- [x] New test case passes: verifies current branch is not deleted even when merged
- [x] All existing tests continue to pass
- [x] Manual testing confirms fix works in real scenarios
- [x] Build and formatting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)